### PR TITLE
Cleanup Database logic.

### DIFF
--- a/src/main/java/net/forsaken_borders/DatabaseManager.java
+++ b/src/main/java/net/forsaken_borders/DatabaseManager.java
@@ -18,7 +18,7 @@ public class DatabaseManager {
 
 	public static void createDatabase() {
 		// TODO: Make the Database File Path changeable via a Config
-		boolean newDatabase = new File("database.db").exists();
+		boolean newDatabase = !(new File("database.db").exists());
 
 		// The Commands that are run are from
 		// https://cj.rs/blog/sqlite-pragma-cheatsheet-for-performance-and-consistency/
@@ -51,6 +51,7 @@ public class DatabaseManager {
 
 	public static void migrate() {
 		try {
+			assert Fabrissentials.databaseConnection != null;
 			Statement statement = Fabrissentials.databaseConnection.createStatement();
 			ResultSet versionResult = statement.executeQuery("PRAGMA schema.user_version;");
 			int version = versionResult.getInt("user_version");
@@ -74,14 +75,13 @@ public class DatabaseManager {
 		} catch (SQLException error) {
 			LOGGER.error("Failed to migrate the database!", error);
 		}
-
-		return;
 	}
 
 	public static void populateDatabase() {
 		LOGGER.info("Creating the database...");
 
 		try {
+			assert Fabrissentials.databaseConnection != null;
 			Statement statement = Fabrissentials.databaseConnection.createStatement();
 
 			// Insert the current version of the database
@@ -107,7 +107,6 @@ public class DatabaseManager {
 			statement.close();
 		} catch (SQLException error) {
 			LOGGER.error("Failed to create the database!", error);
-			return;
 		}
 	}
 

--- a/src/main/java/net/forsaken_borders/DatabaseManager.java
+++ b/src/main/java/net/forsaken_borders/DatabaseManager.java
@@ -1,0 +1,143 @@
+package net.forsaken_borders;
+
+import java.io.File;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DatabaseManager {
+	private static final int DATABASE_VERSION = 1;
+	private static final Properties DATABASE_PROPERTIES = new Properties();
+
+	public static final Logger LOGGER = LoggerFactory.getLogger("fabrissentials.database");
+
+	public static void createDatabase() {
+		// TODO: Make the Database File Path changeable via a Config
+		boolean newDatabase = new File("database.db").exists();
+
+		// The Commands that are run are from
+		// https://cj.rs/blog/sqlite-pragma-cheatsheet-for-performance-and-consistency/
+		// Archived Site:
+		// https://web.archive.org/web/20230120235214/https://cj.rs/blog/sqlite-pragma-cheatsheet-for-performance-and-consistency/
+		// These basically make the Database more performant and ensure integrity
+		// I've tried running these as normal Statements, like you should/can in "normal
+		// SQLite" but they throw various exceptions, so this will have to do.
+		DATABASE_PROPERTIES.setProperty("journal_mode", "WAL");
+		DATABASE_PROPERTIES.setProperty("synchronous", "normal");
+		DATABASE_PROPERTIES.setProperty("foreign_keys", "on");
+
+		try {
+			Fabrissentials.databaseConnection = DriverManager.getConnection("jdbc:sqlite:database.db",
+					DATABASE_PROPERTIES);
+		} catch (Exception error) {
+			LOGGER.error("Failed to create the database connection!", error);
+			return;
+		}
+
+		if (newDatabase) {
+			// If the database is new, we need to create the tables
+			populateDatabase();
+		} else {
+			// If the database is not new, we need to transfer the data from the old
+			// database into the new database format.
+			migrate();
+		}
+	}
+
+	public static void migrate() {
+		try {
+			Statement statement = Fabrissentials.databaseConnection.createStatement();
+			ResultSet versionResult = statement.executeQuery("PRAGMA schema.user_version;");
+			int version = versionResult.getInt("user_version");
+
+			switch (version) {
+				case DATABASE_VERSION:
+					// Currently we're on this version and no work needs to be done.
+					break;
+				default:
+					// We're on an unknown version, likely a newer version than the current one.
+					// Do NOT attempt to touch the database as it may cause data loss.
+					LOGGER.error(
+							"The database is on an unknown version! ({}), please ensure you're using the latest version of Fabrissentials!",
+							version);
+					break;
+			}
+
+			// Set the database version to the current version on a successful migration.
+			statement.execute("PRAGMA schema.user_version = " + DATABASE_VERSION + ";");
+			statement.close();
+		} catch (SQLException error) {
+			LOGGER.error("Failed to migrate the database!", error);
+		}
+
+		return;
+	}
+
+	public static void populateDatabase() {
+		LOGGER.info("Creating the database...");
+
+		try {
+			Statement statement = Fabrissentials.databaseConnection.createStatement();
+
+			// Insert the current version of the database
+			statement.execute("PRAGMA schema.user_version = " + DATABASE_VERSION + ";");
+
+			// Create the homes table for the /home command
+			statement.execute(
+					"CREATE TABLE IF NOT EXISTS \"Homes\" (\"HomeID\" TEXT NOT NULL, \"PlayerID\" BLOB NOT NULL, \"WorldID\" BLOB NOT NULL, \"X\" REAL NOT NULL, \"Y\" REAL NOT NULL, \"Z\" REAL NOT NULL, \"Pitch\" REAL NOT NULL, \"Yaw\" REAL NOT NULL);");
+
+			// Ensure that each player doesn't have multiple homes with the same name,
+			// though there can be multiple homes with the same name, unique to each player
+			statement.execute(
+					"ALTER TABLE \"Homes\" ADD CONSTRAINT \"UniqueHomeIdPerPlayer\" UNIQUE (\"HomeID\", \"PlayerID\");");
+
+			// Create the warps table for the /warp command
+			statement.execute(
+					"CREATE TABLE IF NOT EXISTS \"Warps\" (\"WarpID\" TEXT NOT NULL, \"PlayerID\" BLOB NOT NULL, \"WorldID\" BLOB NOT NULL, \"X\" REAL NOT NULL, \"Y\" REAL NOT NULL, \"Z\" REAL NOT NULL, \"Pitch\" REAL NOT NULL, \"Yaw\" REAL NOT NULL);");
+
+			// Ensure that each warp doesn't have the same id.
+			statement.execute("ALTER TABLE \"Warps\" ADD CONSTRAINT \"UniqueWarpId\" UNIQUE (\"WarpID\");");
+
+			// Close the statement
+			statement.close();
+		} catch (SQLException error) {
+			LOGGER.error("Failed to create the database!", error);
+			return;
+		}
+	}
+
+	public static void closeDatabase() {
+		if (Fabrissentials.databaseConnection != null) {
+			try {
+				Statement statement = Fabrissentials.databaseConnection.createStatement();
+
+				// The default value is 400, but we're going to set it to 1000 to allow for
+				// longer and more efficient analysis.
+				statement.execute("PRAGMA analysis_limit=1000;");
+
+				// "Housekeeping" - Aaron
+				statement.execute("PRAGMA optimize;");
+				statement.close();
+			} catch (SQLException exception) {
+				LOGGER.warn(
+						"An unexpected error had occured, please report this to Fabrissentials' GitHub page!",
+						exception);
+			}
+		}
+
+		if (Fabrissentials.databaseConnection != null) {
+			try {
+				Fabrissentials.databaseConnection.close();
+			} catch (SQLException exception) {
+				LOGGER.error(
+						"An unexpected error occurred trying to close the database. It's possible some data loss occured, please create a backup of the database before attempting to run Fabrissentials again.",
+						exception);
+			}
+		}
+	}
+}

--- a/src/main/java/net/forsaken_borders/DatabaseManager.java
+++ b/src/main/java/net/forsaken_borders/DatabaseManager.java
@@ -16,9 +16,9 @@ public class DatabaseManager {
 
 	public static final Logger LOGGER = LoggerFactory.getLogger("fabrissentials.database");
 
-	public static void createDatabase() {
+	public static void create() {
 		// TODO: Make the Database File Path changeable via a Config
-		boolean newDatabase = !(new File("database.db").exists());
+		boolean newDatabase = !new File("database.db").exists();
 
 		// The Commands that are run are from
 		// https://cj.rs/blog/sqlite-pragma-cheatsheet-for-performance-and-consistency/
@@ -41,7 +41,7 @@ public class DatabaseManager {
 
 		if (newDatabase) {
 			// If the database is new, we need to create the tables
-			populateDatabase();
+			populate();
 		} else {
 			// If the database is not new, we need to transfer the data from the old
 			// database into the new database format.
@@ -50,8 +50,9 @@ public class DatabaseManager {
 	}
 
 	public static void migrate() {
+		assert Fabrissentials.databaseConnection != null;
+
 		try {
-			assert Fabrissentials.databaseConnection != null;
 			Statement statement = Fabrissentials.databaseConnection.createStatement();
 			ResultSet versionResult = statement.executeQuery("PRAGMA schema.user_version;");
 			int version = versionResult.getInt("user_version");
@@ -77,11 +78,11 @@ public class DatabaseManager {
 		}
 	}
 
-	public static void populateDatabase() {
+	public static void populate() {
+		assert Fabrissentials.databaseConnection != null;
 		LOGGER.info("Creating the database...");
 
 		try {
-			assert Fabrissentials.databaseConnection != null;
 			Statement statement = Fabrissentials.databaseConnection.createStatement();
 
 			// Insert the current version of the database
@@ -110,7 +111,7 @@ public class DatabaseManager {
 		}
 	}
 
-	public static void closeDatabase() {
+	public static void close() {
 		if (Fabrissentials.databaseConnection != null) {
 			try {
 				Statement statement = Fabrissentials.databaseConnection.createStatement();

--- a/src/main/java/net/forsaken_borders/DatabaseManager.java
+++ b/src/main/java/net/forsaken_borders/DatabaseManager.java
@@ -11,11 +11,30 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DatabaseManager {
+	/***
+	 * The current version of the database. This is used for database migrations and
+	 * future proofing. Modify this when tables have changed in any form.
+	 */
 	private static final int DATABASE_VERSION = 1;
+
+	/***
+	 * The properties that are used when creating the database connection. This is
+	 * used to set the database properties, like the journal mode, foreign keys and
+	 * more.
+	 */
 	private static final Properties DATABASE_PROPERTIES = new Properties();
 
+	/***
+	 * The logger that is used to log errors and other messages.
+	 */
 	public static final Logger LOGGER = LoggerFactory.getLogger("fabrissentials.database");
 
+	/***
+	 * Creates the database connection and creates the tables if the database is
+	 * new.
+	 * If the database is not new, it will migrate the data from the old database
+	 * format into the new one.
+	 */
 	public static void create() {
 		// TODO: Make the Database File Path changeable via a Config
 		boolean newDatabase = !new File("database.db").exists();
@@ -49,6 +68,12 @@ public class DatabaseManager {
 		}
 	}
 
+	/***
+	 * Performs a database migration. This will migrate the data from the old
+	 * database format into the new one. This will also set the database version to
+	 * the current version. This method will not do anything if the database is on
+	 * the current version. Under no circumstances should data loss occur.
+	 */
 	public static void migrate() {
 		assert Fabrissentials.databaseConnection != null;
 
@@ -78,6 +103,10 @@ public class DatabaseManager {
 		}
 	}
 
+	/***
+	 * Creates the tables for the database. This will also set the database version
+	 * to the current version.
+	 */
 	public static void populate() {
 		assert Fabrissentials.databaseConnection != null;
 		LOGGER.info("Creating the database...");
@@ -111,6 +140,10 @@ public class DatabaseManager {
 		}
 	}
 
+	/***
+	 * Closes the database connection and performs some "housekeeping" on the
+	 * database.
+	 */
 	public static void close() {
 		if (Fabrissentials.databaseConnection != null) {
 			try {

--- a/src/main/java/net/forsaken_borders/Fabrissentials.java
+++ b/src/main/java/net/forsaken_borders/Fabrissentials.java
@@ -18,12 +18,12 @@ public class Fabrissentials implements DedicatedServerModInitializer {
 		ServerLifecycleEvents.SERVER_STARTING.register(server -> {
 			// This method will create the database, migrate it if required or create the
 			// tables if the database is new.
-			DatabaseManager.createDatabase();
+			DatabaseManager.create();
 		});
 
 		ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
 			// Saves the data, performs "optimization" and closes the database.
-			DatabaseManager.closeDatabase();
+			DatabaseManager.close();
 		});
 
 		LOGGER.info("Hello Fabric world!");

--- a/src/main/java/net/forsaken_borders/Fabrissentials.java
+++ b/src/main/java/net/forsaken_borders/Fabrissentials.java
@@ -1,90 +1,29 @@
 package net.forsaken_borders;
 
-import net.fabricmc.api.DedicatedServerModInitializer;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import java.sql.Connection;
+
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Properties;
+import net.fabricmc.api.DedicatedServerModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 
 public class Fabrissentials implements DedicatedServerModInitializer {
-
-	private static final Properties DATABASE_PROPERTIES = new Properties();
-
 	public static @Nullable Connection databaseConnection;
 	public static final Logger LOGGER = LoggerFactory.getLogger("fabrissentials");
 
 	@Override
 	public void onInitializeServer() {
-
 		ServerLifecycleEvents.SERVER_STARTING.register(server -> {
-			//TODO: Make the Database File Path changeable via a Config
-			try {
-				boolean newDatabase = new File("Database.db").exists();
-
-				// The Commands that are run are from https://cj.rs/blog/sqlite-pragma-cheatsheet-for-performance-and-consistency/
-				// Archived Site: https://web.archive.org/web/20230120235214/https://cj.rs/blog/sqlite-pragma-cheatsheet-for-performance-and-consistency/
-				// These basically make the Database more performant and ensure integrity
-				// I've tried running these as normal Statements, like you should/can in "normal SQLite" but they throw various exceptions, so this will have to do.
-				DATABASE_PROPERTIES.setProperty("journal_mode", "WAL");
-				DATABASE_PROPERTIES.setProperty("synchronous", "normal");
-				DATABASE_PROPERTIES.setProperty("foreign_keys", "on");
-
-				databaseConnection = DriverManager.getConnection("jdbc:sqlite:Database.db", DATABASE_PROPERTIES);
-				if (databaseConnection == null) {
-					LOGGER.error("Database Connection is NULL!");
-					return;
-				}
-
-				if (newDatabase) {
-					LOGGER.info("Seems like this is the first time you are running Fabrissentials.");
-					LOGGER.info("Creating a Database, this might take a while...");
-
-					Statement statement = databaseConnection.createStatement();
-
-					statement.execute("CREATE TABLE IF NOT EXISTS \"Homes\" (\"HomeID\" TEXT NOT NULL, \"PlayerID\" BLOB NOT NULL, \"WorldID\" BLOB NOT NULL, \"X\" REAL NOT NULL, \"Y\" REAL NOT NULL, \"Z\" REAL NOT NULL, \"Pitch\" REAL NOT NULL, \"Yaw\" REAL NOT NULL);");
-					statement.execute("ALTER TABLE \"Homes\" ADD CONSTRAINT \"UniqueHomeIdPerPlayer\" UNIQUE (\"HomeID\", \"PlayerID\");");
-
-					statement.execute("CREATE TABLE IF NOT EXISTS \"Warps\" (\"WarpID\" TEXT NOT NULL, \"PlayerID\" BLOB NOT NULL, \"WorldID\" BLOB NOT NULL, \"X\" REAL NOT NULL, \"Y\" REAL NOT NULL, \"Z\" REAL NOT NULL, \"Pitch\" REAL NOT NULL, \"Yaw\" REAL NOT NULL);");
-					statement.execute("ALTER TABLE \"Warps\" ADD CONSTRAINT \"UniqueWarpId\" UNIQUE (\"WarpID\");");
-
-					statement.close();
-				}
-			} catch (SQLException exception) {
-				LOGGER.error("An Error occurred trying to load the Database!", exception);
-				return;
-			}
-
-			LOGGER.info("Database is ready.");
+			// This method will create the database, migrate it if required or create the
+			// tables if the database is new.
+			DatabaseManager.createDatabase();
 		});
 
 		ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
-			if (databaseConnection != null) {
-				try {
-					Statement statement = databaseConnection.createStatement();
-					statement.execute("PRAGMA analysis_limit=1000;");
-					statement.execute("PRAGMA optimize;");
-					statement.close();
-				} catch (SQLException exception) {
-					LOGGER.warn("An Error occurred trying to prepare the Database for closing. This is usually not a big problem!", exception);
-				}
-			}
-
-			if (databaseConnection != null) {
-				try {
-					databaseConnection.close();
-				} catch (SQLException exception) {
-					LOGGER.error("An Error occurred trying to close the Database, some Data may be lost!", exception);
-				}
-			}
-
-			LOGGER.info("Database closed. Goodbye!");
+			// Saves the data, performs "optimization" and closes the database.
+			DatabaseManager.closeDatabase();
 		});
 
 		LOGGER.info("Hello Fabric world!");


### PR DESCRIPTION
This PR moves the database logic from the main Fabrissentials class to it's own DatabaseManager class. Additionally, by making use of the `pragma_user_version` SQLite property, we can add support for migrations, thusly future proofing the database. Additionally we add a `DATABASE_VERSION` constant which should be updated everytime the tables are modified.