### PR TITLE
Feature/modrinth publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,22 +10,22 @@ jobs:
   build:
     runs-on: self-hosted
     steps:
-      - name: checkout repository
+      - name: Checkout
         uses: actions/checkout@v3
-      - name: validate gradle wrapper
+
+      - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: setup jdk 17
+
+      - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: 'microsoft'
-      - name: make gradle wrapper executable
-        if: ${{ runner.os != 'Windows' }}
-        run: chmod +x ./gradlew
-      - name: build
-        run: ./gradlew build
-      - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
+          distribution: 'temurin'
+
+      - name: Build
+        run: chmod +x ./gradlew && ./gradlew build
+
+      - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
           name: Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Publish Release
+on:
+  release:
+    types: ["published"]
+
+jobs:
+  nuget-release:
+    name: Publish to Modrinth and Github
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+
+      - name: Build
+        run: chmod +x ./gradlew \
+          && source tools/quote.sh \
+          && sed -i "/mod_version/cmod_version=${{ github.ref }} gradle.properties" \
+          && sed -i "/changelog = 'No changelog was specified.'/cchangelog = '${{ github.event.release.body }}'" \
+          && ./gradlew build
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Artifacts
+          path: build/libs/
+
+      - name: Upload Artifacts To Github Release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifactErrorsFailBuild: true
+          artifacts: build/libs/*.jar
+          token: ${{ secrets.GITHUB_TOKEN }}
+          omitBodyDuringUpdate: true # We don't want to update the body of the release.
+          omitNameDuringUpdate: true # We don't want to update the name of the release.

--- a/build.gradle
+++ b/build.gradle
@@ -98,4 +98,5 @@ modrinth {
             new ModDependency('P7dR8mSH', DependencyType.REQUIRED), // Fabric API
             new ModDependency('Vebnzrzj', DependencyType.OPTIONAL) // LuckPerms
     ]
+    changelog = 'No changelog was specified.'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'fabric-loom' version '1.0-SNAPSHOT'
 	id 'maven-publish'
+    id "com.modrinth.minotaur" version "2.+"
 }
 
 sourceCompatibility = JavaVersion.VERSION_17
@@ -82,4 +83,19 @@ publishing {
 		// The repositories here will be used for publishing your artifact, not for
 		// retrieving dependencies.
 	}
+}
+
+
+import com.modrinth.minotaur.dependencies.DependencyType
+import com.modrinth.minotaur.dependencies.ModDependency
+modrinth {
+    projectId = '4egcgHJE'
+    versionNumber = 'project.version'
+    uploadFile = remapJar
+    gameVersions = [project.minecraft_version]
+    loaders = ['fabric']
+    dependencies = [
+            new ModDependency('P7dR8mSH', DependencyType.REQUIRED), // Fabric API
+            new ModDependency('Vebnzrzj', DependencyType.OPTIONAL) // LuckPerms
+    ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ import com.modrinth.minotaur.dependencies.DependencyType
 import com.modrinth.minotaur.dependencies.ModDependency
 modrinth {
     projectId = '4egcgHJE'
-    versionNumber = 'project.version'
+    versionNumber = project.version
     uploadFile = remapJar
     gameVersions = [project.minecraft_version]
     loaders = ['fabric']

--- a/tools/quote.sh
+++ b/tools/quote.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# https://unix.stackexchange.com/a/244556
+quote () {
+    local quoted=${1//\'/\'\\\'\'};
+    printf "'%s'" "$quoted"
+}


### PR DESCRIPTION
Only needs the Modrinth Token in the env var $MODRINTH_TOKEN, and we should be good to go! Allows us to publish a new version using `gradle modrinth`